### PR TITLE
Adapt tests to new actions/core implementation

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 env:
   API_KEY: ${{ secrets.API_KEY }}
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [14.x, 16.x, 18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.2.5",
+        "@actions/core": "^1.11.1",
         "acorn": "^8.8.0",
         "axios": "^1.7.8",
         "form-data": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/McCzarny/upload-image#readme",
   "dependencies": {
-    "@actions/core": "^1.2.5",
+    "@actions/core": "^1.11.1",
     "acorn": "^8.8.0",
     "axios": "^1.7.8",
     "form-data": "^4.0.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,71 @@ const process = require('process');
 const cp = require('child_process');
 const path = require('path');
 const assert = require('assert');
+const fs = require('fs');
+
+
+const setInput = (name, value) =>
+  (process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] = value);
+
+/**
+ * Generate a random path for the github output file and create it.
+ * @return {string} Randomized name for the github output file
+ */
+function generateGithubOutputFile() {
+  const timestamp = new Date().toISOString().replace(/[-:.]/g, '');
+  const random = ('' + Math.random()).substring(2, 8);
+  const fullPath = path.join(__dirname, 'GITHUB_OUTPUT_' + timestamp+random);
+  fs.writeFileSync(fullPath, '');
+  return fullPath;
+}
+
+/**
+ * Method to get the value of an output from the github output file.
+ * The implementation is only for these tests to work. Don't take it as a
+ * reference for your own code.
+ * The github output file has content like this:
+ *
+ * url<<ghadelimiter_UUID
+ * https://i.ibb.co/url.png
+ * ghadelimiter_UUID
+ * @param {string} githubOutputPath The path to the github output file.
+ * @param {string} key The key to get the value from.
+ * @return {string} The value of the key or unndefined if the key doesn't exist.
+ */
+function getValueFromGithubOutput(githubOutputPath, key) {
+  const content = fs.readFileSync(githubOutputPath, 'utf8');
+  const lines = content.split('\n');
+  const keyLine = lines.find((line) => line.startsWith(key));
+  if (!keyLine) {
+    return undefined;
+  }
+
+  let value = '';
+  for (let i = lines.indexOf(keyLine) + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith('ghadelimiter_')) {
+      break;
+    }
+    value += line;
+  }
+
+  return value;
+}
+
+// Shared variables
+let githubOutputPath;
+
+// Setup
+
+beforeEach(() => {
+  githubOutputPath = generateGithubOutputFile();
+});
+
+// Teardown
+
+afterEach(() => {
+  fs.unlinkSync(githubOutputPath);
+});
 
 /**
  * Tests for index.js.
@@ -11,19 +76,28 @@ const assert = require('assert');
 
 // shows how the runner will run a javascript action with env / stdout protocol
 test('upload an image using index.js', () => {
-  const setInput = (name, value) =>
-    (process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] = value);
   setInput('path', 'test-resources/0.png');
   setInput('uploadMethod', 'imgbb');
   setInput('apiKey', process.env['API_KEY']);
   const ip = path.join(__dirname, '..', 'index.js');
-  const result = cp.execSync(`node ${ip}`, {env: process.env}).toString();
-  expect(result).toMatch(new RegExp('::set-output name=url::https:\\/\\/i.ibb.co\\/.*\\.png'));
+  process.env['GITHUB_OUTPUT'] = githubOutputPath;
+  try {
+    const childProcess = cp.execSync(`node ${ip}`, {env: process.env});
+    console.log(childProcess.toString());
+  } catch (error) {
+    console.log(error);
+    console.log('std out:' + new TextDecoder().decode(error.stdout));
+    throw error;
+  }
+  // Expect that GITHUB_OUTPUT contains the url of the uploaded image
+  const fileExists = fs.existsSync(githubOutputPath);
+  expect(fileExists).toBe(true);
+
+  const url = getValueFromGithubOutput(githubOutputPath, 'url');
+  expect(url).toMatch(/https:\/\/i\.ibb\.co\/.*\.png/);
 });
 
 test('upload using index.js with an invalid API key, expect a failure', () => {
-  const setInput = (name, value) =>
-    (process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] = value);
   setInput('path', 'test-resources/0.png');
   setInput('uploadMethod', 'imgbb');
   setInput('apiKey', 'invalid API key');
@@ -40,18 +114,29 @@ test('upload using index.js with an invalid API key, expect a failure', () => {
 });
 
 test('upload multiple images using index.js', () => {
-  const setInput = (name, value) =>
-    (process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] = value);
   setInput('path', 'test-resources/0.png\ntest-resources/1.png\ntest-resources/2.png');
   setInput('uploadMethod', 'imgbb');
   setInput('apiKey', process.env['API_KEY']);
   const ip = path.join(__dirname, '..', 'index.js');
-  const result = cp.execSync(`node ${ip}`, {env: process.env}).toString();
-  expect(result).toMatch(new RegExp('::set-output name=url::(https:\\/\\/i.ibb.co\\/.*\\.png(%0A)?){3}'));
+  process.env['GITHUB_OUTPUT'] = githubOutputPath;
+
+  try {
+    const childProcess = cp.execSync(`node ${ip}`, {env: process.env});
+    console.log(childProcess.toString());
+  } catch (error) {
+    console.log(error);
+    console.log('std out:' + new TextDecoder().decode(error.stdout));
+    throw error;
+  }
+
+  // Expect that GITHUB_OUTPUT contains the url of the uploaded image
+  const fileExists = fs.existsSync(githubOutputPath);
+  expect(fileExists).toBe(true);
+  const url = getValueFromGithubOutput(githubOutputPath, 'url');
+  expect(url).toMatch(new RegExp('(https:\\/\\/i.ibb.co\\/.*\\.png(%0A)?){3}'));
 });
+
 test('upload multiple with index.js with a single invalid path, expect a failure', () => {
-  const setInput = (name, value) =>
-    (process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] = value);
   setInput('path', 'test-resources/0.png\ntest-resources/1.png\ntest-resources/INVALID');
   setInput('uploadMethod', 'imgbb');
   setInput('apiKey', process.env['API_KEY']);

--- a/test/uploadImage.test.js
+++ b/test/uploadImage.test.js
@@ -9,7 +9,6 @@ const assert = require('assert');
  */
 
 test('upload an image', async () => {
-  console.log(process.env);
   const url = await uploadImage(
       'test-resources/0.png',
       'imgbb',


### PR DESCRIPTION
actions/core logic changed:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Before was:
`echo "::set-output name={name}::{value}"`

Now it is:
`echo "{name}={value}" >> $GITHUB_OUTPUT`
